### PR TITLE
Replace noop function with Function.prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,5 @@ function subscribe(subscribers, callback) {
 		return function() { unsubscribe(subscribers, callback); };
 	}
 
-	return noop;
+	return Function.prototype;
 }
-
-function noop() {}


### PR DESCRIPTION
Replace `function noop() {}` with `Function.prototype` according to [ECMA-262 5.1 (15.3.4)](http://www.ecma-international.org/ecma-262/5.1/#sec-15.3.4) and [ECMA-262 6 (19.2.3)](http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-function-prototype-object)